### PR TITLE
enable authentication for retrieving dataset infos

### DIFF
--- a/src/nomad_utility_workflows/utils/core.py
+++ b/src/nomad_utility_workflows/utils/core.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Any, Optional, TypedDict
 

--- a/src/nomad_utility_workflows/utils/datasets.py
+++ b/src/nomad_utility_workflows/utils/datasets.py
@@ -112,7 +112,9 @@ def get_dataset_by_id(dataset_id: str,
     return datasets[0]
 
 
-def create_dataset(dataset_name: str, url: Optional[str] = None, timeout_in_sec: int = 10) -> str:
+def create_dataset(dataset_name: str, 
+                   url: Optional[str] = None, 
+                   timeout_in_sec: int = 10) -> str:
     url = get_nomad_url(url)
     url_name = get_nomad_url_name(url)
     logger.info('creating dataset name %s on %s server', dataset_name, url_name)
@@ -129,7 +131,9 @@ def create_dataset(dataset_name: str, url: Optional[str] = None, timeout_in_sec:
     return response.get('dataset_id')
 
 
-def delete_dataset(dataset_id: str, url: Optional[str] = None, timeout_in_sec: int = 10) -> None:
+def delete_dataset(dataset_id: str, 
+                   url: Optional[str] = None, 
+                   timeout_in_sec: int = 10) -> None:
     url = get_nomad_url(url)
     url_name = get_nomad_url_name(url)
     logger.info('deleting dataset %s on %s server', dataset_id, url_name)

--- a/src/nomad_utility_workflows/utils/datasets.py
+++ b/src/nomad_utility_workflows/utils/datasets.py
@@ -62,6 +62,7 @@ class NomadDataset:
 def retrieve_datasets(
     dataset_params: DatasetParams = default_dataset_params.copy(),
     url: str = None,
+    with_authentication: bool = False,
 ) -> list[NomadDataset]:
     parameters = []
     max_datasets = dataset_params.pop(
@@ -86,7 +87,10 @@ def retrieve_datasets(
             else section
         )
         response = get_nomad_request(
-            RequestOptions(section=section, headers=headers, url=url)
+            RequestOptions(section=section, 
+                           headers=headers, 
+                           url=url, 
+                           with_authentication=with_authentication)
         )
         if len(response['data']) == 0:
             break
@@ -97,8 +101,12 @@ def retrieve_datasets(
     return datasets
 
 
-def get_dataset_by_id(dataset_id: str, url: str = None) -> NomadDataset:
-    datasets = retrieve_datasets(DatasetParams(dataset_id=dataset_id), url=url)
+def get_dataset_by_id(dataset_id: str, 
+                      url: str = None, 
+                      with_authentication: bool = False) -> NomadDataset:
+    datasets = retrieve_datasets(DatasetParams(dataset_id=dataset_id), 
+                                 url=url, 
+                                 with_authentication=with_authentication)
     if len(datasets) != 1:
         raise ValueError(f'Problem retrieving dataset {dataset_id}: {datasets}')
     return datasets[0]

--- a/src/nomad_utility_workflows/utils/uploads.py
+++ b/src/nomad_utility_workflows/utils/uploads.py
@@ -96,7 +96,8 @@ class NomadUpload:
 
 
 @ttl_cache(maxsize=128, ttl=180)
-def get_all_my_uploads(url: Optional[str] = None, timeout_in_sec: int = 10) -> list[NomadUpload]:
+def get_all_my_uploads(url: Optional[str] = None, 
+                       timeout_in_sec: int = 10) -> list[NomadUpload]:
     url = get_nomad_url(url)
     url_name = get_nomad_url_name(url)
     logger.info('retrieving all uploads on %s server', url_name)
@@ -172,7 +173,9 @@ def upload_files_to_nomad(
         logger.error('could not upload %s. Response %s', filename, response)
 
 
-def publish_upload(upload_id: str, url: Optional[str] = None, timeout_in_sec: int = 10) -> dict:
+def publish_upload(upload_id: str, 
+                   url: Optional[str] = None, 
+                   timeout_in_sec: int = 10) -> dict:
     url = get_nomad_url(url)
     url_name = get_nomad_url_name(url)
     logger.info('publishing upload %s on %s server', upload_id, url_name)


### PR DESCRIPTION
This change allows to require authentication for retrieving datasets and getting a dataset by id. This is necessary for non-public Oasis instances.